### PR TITLE
docs: fix CommonJS import syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ import Pagination from '@rizkyalam/pagination'
 
 // or
 
-const Pagination from '@rizkyalam/pagination'
+const Pagination = require('@rizkyalam/pagination')
 ```
 ### Directly in HTML
 


### PR DESCRIPTION
A small improvement in the documentation, about the wrong CommonJS import syntax which will appear as a syntax error.